### PR TITLE
Added cross scala 2.10 and 2.11 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,9 @@
 name := "scala-aws-lambda-utils"
 organization := "io.github.yeghishe"
 version := "0.0.3"
-scalaVersion := "2.12.1"
+val primaryScalaVersion = "2.12.1"
+crossScalaVersions := Seq("2.10.6", "2.11.8", primaryScalaVersion)
+scalaVersion := primaryScalaVersion
 scalacOptions := Seq("-unchecked", "-feature", "-deprecation", "-encoding", "utf8")
 
 resolvers += Resolver.jcenterRepo

--- a/src/main/scala/io/github/yeghishe/lambda/Encoding.scala
+++ b/src/main/scala/io/github/yeghishe/lambda/Encoding.scala
@@ -3,15 +3,20 @@ package io.github.yeghishe.lambda
 import java.io.{InputStream, OutputStream}
 
 import scala.io.Source
-import scala.util.Try
+import scala.util.{Try, Success, Failure}
 
 private[lambda] object Encoding {
   import io.circe._
   import io.circe.parser._
   import io.circe.syntax._
 
+  def toTry[A <: Exception, B](either: Either[A, B]): Try[B] = either match {
+    case Right(b) => Success(b)
+    case Left(a)  => Failure(a)
+  }
+
   def in[T](is: InputStream)(implicit decoder: Decoder[T]): Try[T] = {
-    val t = Try(Source.fromInputStream(is).mkString).flatMap(decode[T](_).toTry)
+    val t = Try(Source.fromInputStream(is).mkString).map(decode[T](_)).flatMap(toTry)
     is.close()
     t
   }


### PR DESCRIPTION
First off, thanks for writing the guide for using AWS Lambda with Scala – it was super helpful, just what I needed.

However, I have to stay with Scala 2.11 for some time, so I made the code compatible with scala 2.10 and 2.11 and added cross scala versions to build.sbt.

To publish multiple scala versions, use sbt action `+ publish`.